### PR TITLE
SFU for atan2() + single precision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 option(FORMAT_CODE "Use clang-format for formatting" OFF)
 option(BUILD_TESTS "Build tests" ON)
 option(USE_SINGLE_PRECISION "Use single precision float" OFF)
+option(USE_SFU "Use special function units" OFF)
 
 # kokkos
 add_compile_options(-Wno-deprecated-declarations)
@@ -37,7 +38,12 @@ target_link_libraries(polyclip PUBLIC Kokkos::kokkos)
 
 # use single precision float
 if (USE_SINGLE_PRECISION)
-  target_compile_definitions(polyclip PUBLIC USE_SINGLE_PRECISION=1)
+  if (USE_SFU)
+    message(STATUS "SINGLE PRECISION ENABLED + SFU ENABLED")
+    target_compile_definitions(polyclip PUBLIC USE_SINGLE_PRECISION=1 USE_SFU=1)
+  else ()
+    target_compile_definitions(polyclip PUBLIC USE_SINGLE_PRECISION=1)
+  endif()  
 endif ()
 
 # tests

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Then build the code with CUDA backend:
 git clone --recursive git@github.com:lanl/polyclip.git
 cd polyclip
 cmake -B build \
-  -DFORMAT_CODE=OFF \          # use clang-format
+  -DFORMAT_CODE=OFF \            # use clang-format
   -DBUILD_TESTS=ON \             # build tests
   -DUSE_SINGLE_PRECISION=OFF \   # use 'float' instead of 'double'
+  -DUSE_SFU=ON \		 # use special function units
   -DKokkos_ENABLE_TESTS=OFF \
   -DKokkos_ENABLE_SERIAL=ON \
   -DKokkos_ENABLE_OPENMP=ON \

--- a/core/geometry.h
+++ b/core/geometry.h
@@ -170,11 +170,19 @@ void list_of_points(int cell,
 KOKKOS_INLINE_FUNCTION
 bool compare_points(const Point p1, const Point p2, Point center_point) {
   constexpr real pi = static_cast<real>(M_PI);
+#ifdef USE_SFU
+  real a1 =
+    (atan2(p1.y - center_point.y, p1.x - center_point.x) * (180 / pi));
+  real a2 =
+    (atan2(p2.y - center_point.y, p2.x - center_point.x) * (180 / pi));
+  return a1 < a2;
+#else
   real a1 =
     (std::atan2(p1.y - center_point.y, p1.x - center_point.x) * (180 / pi));
   real a2 =
     (std::atan2(p2.y - center_point.y, p2.x - center_point.x) * (180 / pi));
   return a1 < a2;
+#endif
 }
 
 // Sort all points based on degrees ///////////////////////////////////////////////////


### PR DESCRIPTION
Updates:

1. Changed std::atan2 to atan2, this allows us to access the CUDA SFUs instead of the std library.
2. Since SFUs only handle float (single precision) variables, I created a new cmake option "DUSE_SFU=ON" which can only be accessed when DUSE_SINGLE_PRECISION=ON
3. Ran experiments for all test on Volta.

GMV Single Precision Results for 0.01 (arch clipping lines): 
<img width="500" height="504" alt="image" src="https://github.com/user-attachments/assets/95cbe2e5-70c7-41b6-8540-d32ea1f9a6ac" />

Runtime Results for 0.01 analysis: 
<img width="2303" height="1156" alt="Screenshot 2025-08-07 at 2 00 48 AM" src="https://github.com/user-attachments/assets/570e2068-5ab0-4574-9a37-19c221d67478" />

Note: The reason why the GMV Results contains gray along the clipping arc is because the intersecting points are inaccurate due to single precision. 
