### PR TITLE
Loop unrolling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(FORMAT_CODE "Use clang-format for formatting" OFF)
 option(BUILD_TESTS "Build tests" ON)
 option(USE_SINGLE_PRECISION "Use single precision float" OFF)
 option(USE_SFU "Use special function units" OFF)
+option(USE_LOOP_UNROLLING "Use special function units" OFF)
 
 # kokkos
 add_compile_options(-Wno-deprecated-declarations)
@@ -35,6 +36,12 @@ else ()
 endif ()
 
 target_link_libraries(polyclip PUBLIC Kokkos::kokkos)
+
+# use loop unrolling
+if (USE_LOOP_UNROLLING)
+	message(STATUS "LOOP UNROLLING ENABLED")
+  target_compile_definitions(polyclip PUBLIC USE_LOOP_UNROLLING=1)
+endif ()
 
 # use single precision float
 if (USE_SINGLE_PRECISION)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ cmake -B build \
   -DFORMAT_CODE=OFF \            # use clang-format
   -DBUILD_TESTS=ON \             # build tests
   -DUSE_SINGLE_PRECISION=OFF \   # use 'float' instead of 'double'
-  -DUSE_SFU=ON \		 # use special function units
+  -DUSE_SFU=OFF \		 # use special function units
+  -DUSE_LOOP_UNROLLING=OFF \	 # use loop unrolling
   -DKokkos_ENABLE_TESTS=OFF \
   -DKokkos_ENABLE_SERIAL=ON \
   -DKokkos_ENABLE_OPENMP=ON \

--- a/core/geometry.h
+++ b/core/geometry.h
@@ -138,13 +138,20 @@ void orientation_clip(int c,
 KOKKOS_INLINE_FUNCTION
 Point center(int c, int n, Kokkos::View<Point**> allPoints) {
   real sumX = 0, sumY = 0;
-
+#ifdef USE_LOOP_UNROLLING
+  // Add up all the coordinates /////
+  #pragma unroll 5
+  for (int p = 0; p < n; p++) { //(const auto &p: nodes) {
+    sumX += allPoints(c, p).x;
+    sumY += allPoints(c, p).y;
+  }
+#else
   // Add up all the coordinates /////
   for (int p = 0; p < n; p++) { //(const auto &p: nodes) {
     sumX += allPoints(c, p).x;
     sumY += allPoints(c, p).y;
   }
-
+#endif
   // Store middle coordinates ///////
   return { sumX / n, sumY / n };
 }
@@ -158,10 +165,19 @@ void list_of_points(int cell,
                     Kokkos::View<Point**> allPoints,
                     Kokkos::View<int*> num_verts_per_cell) {
   int const m = num_verts_per_cell(cell);
+
+#ifdef USE_LOOP_UNROLLING
+#pragma unroll 3
   for (int i = 0; i < m; i++) {
     int index = cells(cell, i, 0);
     allPoints(cell, i) = points(index);
   }
+#else
+  for (int i = 0; i < m; i++) {
+    int index = cells(cell, i, 0);
+    allPoints(cell, i) = points(index);
+  }
+#endif
   allPoints(cell, m) = intersect_points.a;
   allPoints(cell, (m + 1)) = intersect_points.b;
 }


### PR DESCRIPTION
Updates:

1. Updated two for loops to have the option to loop unroll
2. Added new cmake option to loop unroll "USE_LOOP_UNROLLING"
3. Tested only on 0.01 (arc clipping lines) and 0.08 (16 clipping lines)

0.01 no loop unrolling vs loop unrolling:
<img width="2282" height="1041" alt="Screenshot 2025-08-08 at 12 38 43 AM" src="https://github.com/user-attachments/assets/5544c3f3-f883-4c34-90d8-bd171dab5916" />

0.08 no loop unrolling vs loop unrolling:
<img width="2307" height="1051" alt="Screenshot 2025-08-08 at 12 41 12 AM" src="https://github.com/user-attachments/assets/525b8d8e-0afe-40a5-aef1-019bab683d14" />
 unrolling vs loop unrolling:


Notes: 

1. Checked gmv visuals, its working correctly with loop unrolling
2. loop unrolling slightly improves clipping region in 0.01 but this is not the case for 0.08
