### PR TITLE
Loop graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(FORMAT_CODE "Use clang-format for formatting" OFF)
 option(BUILD_TESTS "Build tests" ON)
 option(USE_SINGLE_PRECISION "Use single precision float" OFF)
 option(USE_SFU "Use special function units" OFF)
+option(USE_LOOP_UNROLLING "Use special function units" OFF)
 
 # kokkos
 add_compile_options(-Wno-deprecated-declarations)
@@ -35,6 +36,12 @@ else ()
 endif ()
 
 target_link_libraries(polyclip PUBLIC Kokkos::kokkos)
+
+# use loop unrolling
+if (USE_LOOP_UNROLLING)
+	message(STATUS "LOOP UNROLLING ENABLED")
+  target_compile_definitions(polyclip PUBLIC USE_LOOP_UNROLLING=1)
+endif ()
 
 # use single precision float
 if (USE_SINGLE_PRECISION)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ cmake -B build \
   -DFORMAT_CODE=OFF \            # use clang-format
   -DBUILD_TESTS=ON \             # build tests
   -DUSE_SINGLE_PRECISION=OFF \   # use 'float' instead of 'double'
-  -DUSE_SFU=ON \		 # use special function units
+  -DUSE_SFU=OFF \		 # use special function units
+  -DUSE_LOOP_UNROLLING=OFF \	 # use loop unrolling
   -DKokkos_ENABLE_TESTS=OFF \
   -DKokkos_ENABLE_SERIAL=ON \
   -DKokkos_ENABLE_OPENMP=ON \

--- a/core/geometry.h
+++ b/core/geometry.h
@@ -138,13 +138,20 @@ void orientation_clip(int c,
 KOKKOS_INLINE_FUNCTION
 Point center(int c, int n, Kokkos::View<Point**> allPoints) {
   real sumX = 0, sumY = 0;
-
+#ifdef USE_LOOP_UNROLLING
+  // Add up all the coordinates /////
+  #pragma unroll 5
+  for (int p = 0; p < n; p++) { //(const auto &p: nodes) {
+    sumX += allPoints(c, p).x;
+    sumY += allPoints(c, p).y;
+  }
+#else
   // Add up all the coordinates /////
   for (int p = 0; p < n; p++) { //(const auto &p: nodes) {
     sumX += allPoints(c, p).x;
     sumY += allPoints(c, p).y;
   }
-
+#endif
   // Store middle coordinates ///////
   return { sumX / n, sumY / n };
 }
@@ -158,10 +165,19 @@ void list_of_points(int cell,
                     Kokkos::View<Point**> allPoints,
                     Kokkos::View<int*> num_verts_per_cell) {
   int const m = num_verts_per_cell(cell);
+
+#ifdef USE_LOOP_UNROLLING
+#pragma unroll 3
   for (int i = 0; i < m; i++) {
     int index = cells(cell, i, 0);
     allPoints(cell, i) = points(index);
   }
+#else
+  for (int i = 0; i < m; i++) {
+    int index = cells(cell, i, 0);
+    allPoints(cell, i) = points(index);
+  }
+#endif
   allPoints(cell, m) = intersect_points.a;
   allPoints(cell, (m + 1)) = intersect_points.b;
 }

--- a/scripts/baseline_vs_loop_unrolling.py
+++ b/scripts/baseline_vs_loop_unrolling.py
@@ -1,0 +1,45 @@
+# (c) 2025. Triad National Security, LLC. All rights reserved.
+# This program was produced under U.S. Government contract 89233218CNA000001
+# for Los Alamos National Laboratory (LANL), which is operated by Triad National
+# Security, LLC for the U.S. Department of Energy/National Nuclear Security
+# Administration. All rights in the program are reserved by Triad National
+# Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+# Administration. The Government is granted for itself and others acting on its
+# behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
+# to reproduce, prepare derivative works, distribute copies to the public,
+# perform publicly and display publicly, and to permit others to do so.
+
+import os
+import matplotlib.pyplot as plt
+
+# Duration at Clipping Cells Kokkos Region
+#values = [0.5841, 0.5558]
+values = [0.6108, 0.7840]
+
+# Non-UVM and UVM labels
+labels = ["No Loop Unrolling", "Loop Unrolling"]
+fixed_labels = [label.replace(" ", "\n") for label in labels]
+
+# Create Bar Graph
+plt.figure(figsize=(10, 12))
+x_pos = range(len(labels))
+colors = ['blue', 'orange']
+# Duration Labels
+for i, val in enumerate(values):
+    label = f'{val:.4f} ms'
+    plt.text(i + 0.5, val, label, ha='center', va='bottom',fontsize=14)
+
+plt.bar(x_pos, values, width=1.0, align='edge', color=colors)
+plt.xticks([x + 0.5 for x in x_pos], fixed_labels, rotation=45, ha='right', fontsize=20)
+plt.title("Clipping Runtime", fontsize=30, weight='bold')
+plt.ylabel("Runtime (ms)", fontsize=20)
+plt.ticklabel_format(axis='y', style='plain')
+plt.xticks(rotation=45, ha='right')
+plt.tight_layout()
+
+# Save Figure 
+output_dir = "compare/"
+os.makedirs(output_dir, exist_ok=True)
+output_path = os.path.join(output_dir, "baseline_vs_loop_unrolling.png")
+plt.savefig(output_path)
+plt.close()


### PR DESCRIPTION
Update:

1. New graph for comparing with and without loop unrolling

0.01 + arc clipping lines: 
<img width="1000" height="1200" alt="baseline_vs_loop_unrolling" src="https://github.com/user-attachments/assets/a1a225ba-0ef1-44a0-8b77-e61ae206be70" />


0.08 + 16 clipping lines:
<img width="1000" height="1200" alt="baseline_vs_loop_unrolling" src="https://github.com/user-attachments/assets/65891ec4-30ae-433d-aea3-a93591395785" />
