### PR TITLE
Removed any conversions

### DIFF
--- a/core/geometry.h
+++ b/core/geometry.h
@@ -44,8 +44,13 @@ namespace polyclip {
 
 // x and y values ///////////////////////////////////////////////////////////////////////
 struct Point {
-  real x = 0;
-  real y = 0;
+#ifdef USE_SINGLE_PRECISION
+  real x = 0.f;
+  real y = 0.f;
+#else
+  real x = 0.0;
+  real y = 0.0;
+#endif
 };
 
 struct Segment {
@@ -55,7 +60,12 @@ struct Segment {
 
 struct Line {
   Point n;    // normal
-  real d = 0; // distance
+
+#ifdef USE_SINGLE_PRECISION
+  real d = 0.f; // distance
+#else
+  real d = 0.0;
+#endif
 };
 
 struct Edge {
@@ -98,9 +108,13 @@ Point pointVec(Point const& p, Point const& middle) {
 // Middile Point of the Interface ////////////////////////////////////////////////////////
 KOKKOS_INLINE_FUNCTION
 Point middle_point(Segment const& points) {
-  real mx = (points.a.x + points.b.x) / 2;
-  real my = (points.a.y + points.b.y) / 2;
-
+#ifdef USE_SINGLE_PRECISION
+  real mx = (points.a.x + points.b.x) / 2.0f;
+  real my = (points.a.y + points.b.y) / 2.0f;
+#else
+  real mx = (points.a.x + points.b.x) / 2.0;
+  real my = (points.a.y + points.b.y) / 2.0;
+#endif
   return { mx, my };
 }
 
@@ -185,18 +199,25 @@ void list_of_points(int cell,
 // Compare Points ////////////////////////////////////////////////////////////////////
 KOKKOS_INLINE_FUNCTION
 bool compare_points(const Point p1, const Point p2, Point center_point) {
-  constexpr real pi = static_cast<real>(M_PI);
+#ifdef USE_SINGLE_PRECISION
+  constexpr real pi = 3.14159265f;
+  real degree = 180.0f;
+#else
+  constexpr real pi = M_PI;
+  real degree = 180.0;
+#endif 
+
 #ifdef USE_SFU
   real a1 =
-    (atan2(p1.y - center_point.y, p1.x - center_point.x) * (180 / pi));
+    (atan2(p1.y - center_point.y, p1.x - center_point.x) * (degree / pi));
   real a2 =
-    (atan2(p2.y - center_point.y, p2.x - center_point.x) * (180 / pi));
+    (atan2(p2.y - center_point.y, p2.x - center_point.x) * (degree / pi));
   return a1 < a2;
 #else
   real a1 =
-    (std::atan2(p1.y - center_point.y, p1.x - center_point.x) * (180 / pi));
+    (std::atan2(p1.y - center_point.y, p1.x - center_point.x) * (degree / pi));
   real a2 =
-    (std::atan2(p2.y - center_point.y, p2.x - center_point.x) * (180 / pi));
+    (std::atan2(p2.y - center_point.y, p2.x - center_point.x) * (degree / pi));
   return a1 < a2;
 #endif
 }

--- a/core/intersect_n_d.h
+++ b/core/intersect_n_d.h
@@ -34,8 +34,12 @@ Segment intersect_cell_with_line_n_d(Kokkos::View<Point*> points,
                                      bool use_end_points) {
   int const n = num_verts_per_cell(c);
   Point pts[2];
-  constexpr Point const DUMMY = { std::numeric_limits<real>::max(),
-                                  std::numeric_limits<real>::max() };
+
+#ifdef USE_SINGLE_PRECISION
+  constexpr Point const DUMMY = {FLT_MAX, FLT_MAX};
+#else
+  constexpr Point const DUMMY = {DBL_MAX, DBL_MAX};
+#endif
 
   int k = 0;
 

--- a/scripts/double_vs_single_vs_sfu.py
+++ b/scripts/double_vs_single_vs_sfu.py
@@ -20,13 +20,13 @@ regions = ['CLIPPED PART: \nCPU-TO-GPU TRANSFER',
            'CLIPPED PART: \nGPU-TO-CPU TRANSFER']
 # 0.01 arc 
 #double_precision      = [0.0850, 0.9669, 0.5841, 2.3634]
-#single_precision      = [0.1499, 1.6016, 0.5918, 1.7455]
-#single_precision_sfu  = [0.0835, 1.4340, 0.5325, 1.2882]
+#single_precision      = [0.0980, 1.4039, 0.5439, 1.2921]
+#single_precision_sfu  = [0.0961, 1.4354, 0.5385, 1.2915]
 
 # 0.08 16 lines
-#double_precision      = [0.0597, 0.0847, 0.6108, 0.6585]
-#single_precision      = [0.0804, 0.0982, 0.8058, 0.5875]
-#single_precision_sfu  = [0.0791, 0.0981, 0.7899, 0.3807]
+double_precision      = [0.0597, 0.0847, 0.6108, 0.6585]
+single_precision      = [0.0791, 0.0951, 0.7986, 0.3863]
+single_precision_sfu  = [0.0788, 0.0955, 0.7936, 0.3742]
 
 # 0.08 14 lines
 #double_precision      = [0.0603, 0.0845, 0.5645, 0.6065]
@@ -59,9 +59,9 @@ regions = ['CLIPPED PART: \nCPU-TO-GPU TRANSFER',
 #single_precision_sfu  = [0.0797, 0.0961, 0.4965, 0.2858]
 
 # 0.08 1 lines
-double_precision      = [0.0600, 0.0840, 0.3358, 0.2418]
-single_precision      = [0.0810, 0.0950, 0.4272, 0.2937]
-single_precision_sfu  = [0.0802, 0.0975, 0.4114, 0.2650]
+#double_precision      = [0.0600, 0.0840, 0.3358, 0.2418]
+#single_precision      = [0.0810, 0.0950, 0.4272, 0.2937]
+#single_precision_sfu  = [0.0802, 0.0975, 0.4114, 0.2650]
 
 # X-axis configuration
 x = np.arange(len(regions))  # the label locations


### PR DESCRIPTION
Updates:

1. Removed any possible conversions

0.01 mesh + arc clipping line: 
<img width="1000" height="600" alt="percision_comparison" src="https://github.com/user-attachments/assets/d1bc5df2-9fab-4250-be54-3cfa9ae89c6b" />


0.08 + 16 clipping lines:
<img width="1000" height="600" alt="percision_comparison" src="https://github.com/user-attachments/assets/f23e7a7e-44e6-4654-ba8d-ddc9ee2b05dd" />


Note: 

1. This did speed up the single precision and sfu operations from last time.
2. Speed up for 0.01 but not the case for 0.08 still.